### PR TITLE
[FEAT][#1]: AVI 파일의 전/후방 프레임 추출 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ python_engine/*.egg-info/
 
 # 외부 실행 파일
 bin/
+
+# 샘플 데이터
+python_engine/sampl_video/
+
+# 샘플 출력 결과물
+python_engine/sample_output/

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ python_engine/*.egg-info/
 bin/
 
 # 샘플 데이터
-python_engine/sampl_video/
+python_engine/sample_video/
 
 # 샘플 출력 결과물
 python_engine/sample_output/

--- a/python_engine/core/recovery/avi/avi_split_channel.py
+++ b/python_engine/core/recovery/avi/avi_split_channel.py
@@ -24,11 +24,19 @@ def extract_channel_by_signature(data, signature: bytes, valid_end: int):
         chunk_end = chunk_start + size
 
         # 사이즈 검사
-        if size > MAX_REASONABLE_CHUNK_SIZE or chunk_end > valid_end:
+        # 사이즈 검사
+        if size > MAX_REASONABLE_CHUNK_SIZE:
+            print(f"[경고] 비정상적으로 큰 프레임 (size={size}, offset=0x{index:X})")
             offset = index + 4
             continue
 
         if chunk_end - chunk_start < 5:
+            print(f"[경고] 너무 작은 프레임 (size={size}, offset=0x{index:X})")
+            offset = index + 4
+            continue
+
+        if chunk_end > valid_end:
+            print(f"[경고] 프레임이 파일 끝을 넘어감 (size={size}, offset=0x{index:X})")
             offset = index + 4
             continue
 
@@ -37,6 +45,7 @@ def extract_channel_by_signature(data, signature: bytes, valid_end: int):
         nal_type = data[chunk_start + 4] & 0x1F
 
         if nal_prefix != b'\x00\x00\x00\x01':
+            print(f"[경고] 잘못된 NAL prefix (offset=0x{index:X})")
             offset = index + 4
             continue
 

--- a/python_engine/core/recovery/avi/avi_split_channel.py
+++ b/python_engine/core/recovery/avi/avi_split_channel.py
@@ -1,0 +1,77 @@
+import os
+import struct
+
+INPUT_FILE = "../../../sample_video/sample.avi"
+OUTPUT_DIR = "../../../sample_output"
+
+# 최대 허용 가능한 프레임 크기 (10MB)
+MAX_REASONABLE_CHUNK_SIZE = 10 * 1024 * 1024
+
+def extract_channel_by_signature(data, signature: bytes, valid_end: int):
+    offset = 0
+    count = 0
+    extracted_chunks = []
+
+    while offset < valid_end:
+        index = data.find(signature, offset, valid_end)
+        if index == -1:
+            break
+
+        if index + 8 > valid_end:
+            break
+
+        size_bytes = data[index + 4: index + 8]
+        size = struct.unpack('<I', size_bytes)[0]
+
+        chunk_start = index + 8
+        chunk_end = chunk_start + size
+
+        if size > MAX_REASONABLE_CHUNK_SIZE or chunk_end > valid_end:
+            offset = index + 4
+            continue
+
+        if chunk_end - chunk_start < 5:
+            offset = index + 4
+            continue
+
+        nal_prefix = data[chunk_start:chunk_start + 4]
+        nal_type = data[chunk_start + 4] & 0x1F
+
+        if nal_prefix != b'\x00\x00\x00\x01' or nal_type not in (1, 7):
+            offset = index + 4
+            continue
+
+        extracted_chunks.append(data[chunk_start:chunk_end])
+        count += 1
+        offset = chunk_end
+
+    return extracted_chunks, count
+
+def split_normal_channels():
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    with open(INPUT_FILE, 'rb') as f:
+        data = f.read()
+
+    real_file_size = struct.unpack('<I', data[4:8])[0]
+    valid_end = 8 + real_file_size  # RIFF 헤더 포함한 유효 구간
+
+    # FRONT 채널 추출
+    front_chunks, front_count = extract_channel_by_signature(data, b'00dc', valid_end)
+    front_path = os.path.join(OUTPUT_DIR, 'normal_front.h264')
+    with open(front_path, 'wb') as f:
+        for chunk in front_chunks:
+            f.write(chunk)
+
+    # REAR 채널 추출
+    rear_chunks, rear_count = extract_channel_by_signature(data, b'01dc', valid_end)
+    rear_path = os.path.join(OUTPUT_DIR, 'normal_rear.h264')
+    with open(rear_path, 'wb') as f:
+        for chunk in rear_chunks:
+            f.write(chunk)
+
+    print(f"FRONT 채널: {front_count}개 프레임 → {front_path}")
+    print(f"REAR 채널: {rear_count}개 프레임 → {rear_path}")
+
+if __name__ == "__main__":
+    split_normal_channels()

--- a/python_engine/core/recovery/avi/avi_split_channel.py
+++ b/python_engine/core/recovery/avi/avi_split_channel.py
@@ -1,8 +1,8 @@
 import os
 import struct
 
-INPUT_FILE = "../../../sample_video/sample.avi"
-OUTPUT_DIR = "../../../sample_output"
+INPUT_FILE = r"E:\Retato\python_engine\sample_video\sample.avi"
+OUTPUT_DIR = r"E:\Retato\python_engine\sample_output"
 
 # 최대 허용 가능한 프레임 크기 (10MB)
 MAX_REASONABLE_CHUNK_SIZE = 10 * 1024 * 1024
@@ -12,20 +12,18 @@ def extract_channel_by_signature(data, signature: bytes, valid_end: int):
     count = 0
     extracted_chunks = []
 
+    sps = pps = None # SPS, PPS 저장용
+
     while offset < valid_end:
         index = data.find(signature, offset, valid_end)
-        if index == -1:
+        if index == -1 or index + 8 > valid_end:
             break
 
-        if index + 8 > valid_end:
-            break
-
-        size_bytes = data[index + 4: index + 8]
-        size = struct.unpack('<I', size_bytes)[0]
-
+        size = struct.unpack('<I', data[index + 4: index + 8])[0]
         chunk_start = index + 8
         chunk_end = chunk_start + size
 
+        # 사이즈 검사
         if size > MAX_REASONABLE_CHUNK_SIZE or chunk_end > valid_end:
             offset = index + 4
             continue
@@ -34,18 +32,37 @@ def extract_channel_by_signature(data, signature: bytes, valid_end: int):
             offset = index + 4
             continue
 
+        # NAL 헤더 검사
         nal_prefix = data[chunk_start:chunk_start + 4]
         nal_type = data[chunk_start + 4] & 0x1F
 
-        if nal_prefix != b'\x00\x00\x00\x01' or nal_type not in (1, 7):
+        if nal_prefix != b'\x00\x00\x00\x01':
             offset = index + 4
             continue
 
-        extracted_chunks.append(data[chunk_start:chunk_end])
-        count += 1
-        offset = chunk_end
+        # SPS / PPS 저장
+        if nal_type == 7:
+            sps = data[chunk_start:chunk_end]
+        elif nal_type == 8:
+            pps = data[chunk_start:chunk_end]
 
-    return extracted_chunks, count
+        if nal_type in (1, 5, 7, 8):
+            extracted_chunks.append(data[chunk_start:chunk_end])
+            count += 1
+
+        # 정렬 처리 (짝수 맞추기)
+        aligned_size = size + (size % 2)
+        offset = index + 8 + aligned_size
+
+    return extracted_chunks, count, sps, pps
+
+def write_chunks(filepath, chunks, sps=None, pps=None):
+    with open(filepath, 'wb') as f:
+        if sps and pps:
+            f.write(sps)
+            f.write(pps)
+        for chunk in chunks:
+            f.write(chunk)
 
 def split_normal_channels():
     os.makedirs(OUTPUT_DIR, exist_ok=True)
@@ -56,19 +73,15 @@ def split_normal_channels():
     real_file_size = struct.unpack('<I', data[4:8])[0]
     valid_end = 8 + real_file_size  # RIFF 헤더 포함한 유효 구간
 
-    # FRONT 채널 추출
-    front_chunks, front_count = extract_channel_by_signature(data, b'00dc', valid_end)
+    # FRONT 채널
+    front_chunks, front_count, sps, pps = extract_channel_by_signature(data, b'00dc', valid_end)
     front_path = os.path.join(OUTPUT_DIR, 'normal_front.h264')
-    with open(front_path, 'wb') as f:
-        for chunk in front_chunks:
-            f.write(chunk)
+    write_chunks(front_path, front_chunks, sps, pps)
 
-    # REAR 채널 추출
-    rear_chunks, rear_count = extract_channel_by_signature(data, b'01dc', valid_end)
+    # REAR 채널
+    rear_chunks, rear_count, sps_r, pps_r = extract_channel_by_signature(data, b'01dc', valid_end)
     rear_path = os.path.join(OUTPUT_DIR, 'normal_rear.h264')
-    with open(rear_path, 'wb') as f:
-        for chunk in rear_chunks:
-            f.write(chunk)
+    write_chunks(rear_path, rear_chunks, sps_r, pps_r)
 
     print(f"FRONT 채널: {front_count}개 프레임 → {front_path}")
     print(f"REAR 채널: {rear_count}개 프레임 → {rear_path}")

--- a/python_engine/tests/convert_video.py
+++ b/python_engine/tests/convert_video.py
@@ -1,0 +1,39 @@
+import subprocess
+import os
+
+# ffmpeg.exe 절대경로 (사용자 환경에 맞게 수정하세요)
+FFMPEG_PATH = r"E:\Retato\bin\ffmpeg.exe"
+
+# 입력 H.264 파일과 출력 MP4 파일 경로
+H264_PATH = r"E:\Retato\python_engine\sample_output\normal_rear.h264"
+
+def convert_h264(h264_path, output_path, container_format, fps=30):
+    if not os.path.exists(FFMPEG_PATH):
+        raise FileNotFoundError(f"ffmpeg 실행 파일을 찾을 수 없습니다: {FFMPEG_PATH}")
+    if not os.path.exists(h264_path):
+        raise FileNotFoundError(f"입력 파일이 존재하지 않습니다: {h264_path}")
+    
+    cmd = [
+        FFMPEG_PATH, "-y",
+        "-f", "h264",
+        "-r", str(fps),
+        "-i", h264_path,
+        "-c:v", "copy",
+        output_path
+    ]
+
+    print(f"[FFmpeg] 실행 중: {' '.join(cmd)}")
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if result.returncode != 0:
+        print(f"[오류] FFmpeg 실행 실패:\n{result.stderr}")
+    else:
+        print(f"[성공] 변환 완료: {output_path}")
+
+if __name__ == "__main__":
+    format_choice = input("저장할 포맷을 입력하세요 (mp4 또는 avi): ").strip().lower()
+
+    if format_choice not in ('mp4', 'avi'):
+        print("지원하지 않는 포맷입니다. 'mp4' 또는 'avi' 중 하나를 입력하세요.")
+    else:
+        output_path = H264_PATH.replace(".h264", f".{format_choice}")
+        convert_h264(H264_PATH, output_path, container_format=format_choice)


### PR DESCRIPTION
## 작업 내용
- 손상되었거나 메타데이터가 유실된 `.avi` 파일에서도 복원이 가능하도록, 바이너리 레벨에서 전방(`00dc`), 후방(`01dc`) 프레임 시그니처를 탐색하여 두 채널을 분리 추출하는 기능을 구현했습니다. 
- 추출된 프레임 스트림은 `.h264`로 저장되며, 변환 도구(`convert_video.py`)를 통해 `.mp4` 또는 `.avi`로 컨테이너화가 가능합니다.
- 전/후방 채널을 각각 독립적으로 복원할 수 있도록 설계했습니다.

### 관련 파일 경로
- `python_engine/core/recovery/avi/avi_split_channel.py`: 채널 분리 및 프레임 추출
- `python_engine/tests/convert_video.py`: `.h264` → `.mp4` / `.avi` 변환 테스트

### 스크린샷
![image](https://github.com/user-attachments/assets/c814a41f-87e5-46ec-80e4-c966b4d65c33)
> **설명**: `avi_split_channel.py` 실행 시, 전방(`00dc`) 및 후방(`01dc`) 프레임이 추출되어 `.h264` 파일로 저장되는 로그 출력 화면입니다. 

![image](https://github.com/user-attachments/assets/62f4bbf0-e942-46c8-85b5-4ab43e041853)
> **설명**: `convert_video.py` 실행 시, 터미널에서 `mp4` 또는 `avi` 포맷을 선택하면 추출된 `.h264` 스트림이 해당 포맷으로 컨테이너화됩니다. 

### 참고 사항
- 현재는 테스트를 위해 샘플 AVI 파일을 기준으로 하드코딩된 절대경로(`sample_video/sample.avi`)를 사용하고 있습니다.
- 이후 파일 선택 기능 추가 후 경로 입력 방식은 리팩토링될 예정입니다.

## 리뷰 요구사항
- `extract_channel_by_signature()` 함수에서 NAL 헤더 체크 및 SPS/PPS 삽입 방식이 괜찮은지 확인 부탁드립니다.
- 바이너리(HEX) 레벨에서 전방(`00dc`), 후방(`01dc`) 프레임 시그니처를 탐색하여 채널별로 분리하는 전체 처리 흐름이 적절한지 확인 부탁드립니다.
- 프레임 추출부터 SPS/PPS 삽입, 그리고 정렬 방식까지 채널 분리 로직의 전반적인 흐름이 타당한지 검토 요청드립니다.
- 향후 하드코딩된 경로 관련 리팩토링 방향성에 대해서도 간단한 의견 부탁드립니다.