### PR TITLE
[FEAT][#7]: AVI/MP4 분석 기능 코드 초안

### DIFF
--- a/basic_info_parser.py
+++ b/basic_info_parser.py
@@ -1,0 +1,99 @@
+import os
+import datetime
+import subprocess
+import json
+
+def file_format(file_path):
+    with open(file_path, 'rb') as f:
+        header = f.read(12)
+
+    # AVI: RIFF 헤더
+    if header[0:4] == b'RIFF' and header[8:12] == b'AVI ':
+        return 'AVI'
+
+    # MP4: ftyp 
+    if header[4:8] == b'ftyp':
+        return 'MP4'
+
+    return 'Unknown'
+
+def file_creation_time(file_path):
+    created_timestamp = os.path.getctime(file_path)
+    modified_timestamp = os.path.getmtime(file_path)
+    access_timestamp = os.path.getatime(file_path)
+
+    # 사람이 읽을 수 있는 형태로 변환
+    creation_time = datetime.datetime.fromtimestamp(created_timestamp)
+    modified_time = datetime.datetime.fromtimestamp(modified_timestamp)
+    access_time = datetime.datetime.fromtimestamp(access_timestamp)
+    
+    return creation_time, modified_time, access_time
+
+def video_metadata(file_path):
+    # ffprobe를 사용 > 영상 메타데이터 파싱
+    # 추출 항목: duration, codec, width, height, frame_rate
+    cmd = [
+        'ffprobe',
+        '-v', 'error',
+        '-select_streams', 'v:0',
+        '-show_entries', 'stream=codec_name,width,height,r_frame_rate,duration',
+        '-of', 'json',
+        file_path
+    ]
+
+    try:
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        info = json.loads(result.stdout)
+
+        stream = info['streams'][0]
+        codec = stream.get('codec_name', 'unknown')
+        width = int(stream.get('width', 0))
+        height = int(stream.get('height', 0))
+        duration = float(stream.get('duration', 0.0))
+
+        fps_str = stream.get('r_frame_rate', '0/1')
+        try:
+            frame_rate = eval(fps_str)  # '30/1' → 30.0
+        except:
+            frame_rate = 0.0
+
+        return {
+            'duration': duration,
+            'codec': codec,
+            'width': width,
+            'height': height,
+            'frame_rate': frame_rate
+        }
+
+    except Exception as e:
+        print(f"[오류] 메타데이터 추출 실패: {e}")
+        return {
+            'duration': 0.0,
+            'codec': 'unknown',
+            'width': 0,
+            'height': 0,
+            'frame_rate': 0.0
+        }
+
+def file_size(file_path):
+    # 파일 크기 (bytes 단위) 반환
+    return os.path.getsize(file_path)
+
+if __name__ == "__main__":
+    file_path = r"C:\Users\user\Desktop\devel\WHS\FineVu_X3000NEW_H265_AVI\FineVu_X3000NEW_H265_AVI\샘플\20250410-13h56m01s_N.avi"
+
+    print("\n[파일 기본 정보]\n")
+    print("파일 포맷:", file_format(file_path))
+    
+    created, modified, accessed = file_creation_time(file_path)
+    print("생성 시간:", created)
+    print("수정 시간:", modified)
+    print("마지막 접근 시간:", accessed)
+    
+    print("파일 크기:", file_size(file_path), "bytes")
+
+    meta = video_metadata(file_path)
+    print("재생 시간:", round(meta["duration"], 2), "초")
+    print("비디오 코덱:", meta["codec"])
+    print("해상도:", f"{meta['width']}×{meta['height']}")
+    print("프레임 레이트:", f"{meta['frame_rate']} fps")

--- a/integrity.py
+++ b/integrity.py
@@ -1,0 +1,109 @@
+import struct
+
+def avi_damage_check(file_path):
+    reasons = []
+    try:
+        with open(file_path, 'rb') as f:
+            data = f.read()
+    except Exception as e:
+        print("True")
+        print(f"파일 열기 실패: {e}")
+        return
+
+    # 1. RIFF 헤더 확인
+    if not data.startswith(b'RIFF'):
+        print("True")
+        print("[헤더 손상] 파일이 'RIFF' 시그니처로 시작하지 않습니다.")
+        return
+
+    # 2. 파일 크기 불일치
+    riff_size = struct.unpack('<I', data[4:8])[0] + 8
+    actual_size = len(data)
+    if abs(riff_size - actual_size) > 1024:
+        reasons.append(f"[파일 크기 손상] 'RIFF'에 기록된 크기({riff_size})와 실제 크기({actual_size}) 불일치합니다.")
+
+    # 3. movi 청크 확인
+    if b'movi' not in data:
+        reasons.append("[필수 청크 손상] 'movi' 청크 X → 프레임 누락 가능성이 있습니다.")
+
+    # 4. 프레임 청크 개수 확인
+    front_count = data.count(b'00dc')
+    rear_count = data.count(b'01dc')
+    if front_count == 0 or rear_count == 0:
+        reasons.append("[프레임 청크 식별 불가능] '00dc' 또는 '01dc' 프레임 청크 X → 전/후방 데이터가 없을 가능성이 있습니다.")
+
+    # 최종 출력
+    if reasons:
+        print("True")
+        for r in reasons:
+            print(r)
+    else:
+        print("False")
+
+def mp4_damage_check(file_path):
+    reasons = []
+
+    try:
+        with open(file_path, 'rb') as f:
+            data = f.read()
+    except Exception as e:
+        print("True")
+        print(f"파일 열기 실패: {e}")
+        return
+
+    def find_box(data, box_type):
+        offset = 0
+        while offset < len(data) - 8:
+            try:
+                size = struct.unpack(">I", data[offset:offset+4])[0]
+                typ = data[offset+4:offset+8]
+                if typ == box_type.encode():
+                    return offset, size
+                offset += size if size > 0 else 8
+            except:
+                break
+        return None, None
+
+    # 1. ftyp 박스 확인
+    ftyp_offset, ftyp_size = find_box(data, 'ftyp')
+    if ftyp_offset is None:
+        print("True")
+        print("[필수 atom 손상] 'ftyp' 박스 없음 → MP4 파일 구조가 아닐 가능성이 있습니다.")
+        return
+    elif ftyp_offset != 0:
+        reasons.append(f"[구조 손상] 'ftyp' 박스가 파일 시작이 아님 (offset: {ftyp_offset}) → 비정상 구조일 수 있음.")
+
+    # 2. moov, mdat 박스 확인
+    moov_offset, moov_size = find_box(data, 'moov')
+    mdat_offset, mdat_size = find_box(data, 'mdat')
+
+    if moov_offset is None:
+        reasons.append("[필수 atom 손상] 'moov' 박스 없음 → 메타데이터 손상 가능성이 있습니다.")
+    if mdat_offset is None:
+        reasons.append("[필수 atom 손상] 'mdat' 박스 없음 → 실제 영상 데이터가 없을 수 있습니다.")
+
+    # 3. moov, mdat 순서 확인
+    if moov_offset is not None and mdat_offset is not None:
+        if moov_offset > mdat_offset:
+            reasons.append("'moov' 박스가 'mdat' 뒤에 위치 → 일부 재생기에서 오류 발생할 수 있음.")
+
+    # 최종 출력
+    if reasons:
+        print("True")
+        for r in reasons:
+            print(r)
+    else:
+        print("False")
+
+if __name__ == "__main__":
+    file_path = r"C:\Users\user\Desktop\devel\WHS\FineVu_X3000NEW_H265_AVI\FineVu_X3000NEW_H265_AVI\샘플\20250410-13h56m01s_N.avi"
+
+    print("[무결성 검사 결과]")
+    file_ext = file_path.split('.')[-1].lower()
+
+    if file_ext == 'avi':
+        avi_damage_check(file_path)
+    elif file_ext == 'mp4':
+        mp4_damage_check(file_path)
+    else:
+        print("지원되지 않는 파일 형식입니다.")

--- a/slack.py
+++ b/slack.py
@@ -1,0 +1,143 @@
+import struct
+
+def analyze_mp4_slack(file_path):
+    with open(file_path, 'rb') as f:
+        mp4 = f.read()
+
+    file_size = len(mp4)
+    cursor = 0
+    slack_regions = []
+    total_valid = 0
+    last_box_end = 0
+
+    while cursor + 8 <= file_size:
+        size_bytes = mp4[cursor:cursor+4]
+        type_bytes = mp4[cursor+4:cursor+8]
+
+        try:
+            size = int.from_bytes(size_bytes, 'big')
+            box_type = type_bytes.decode('utf-8', errors='ignore')
+        except:
+            break
+
+        if size < 8 or cursor + size > file_size:
+            break
+
+        box_start = cursor
+        box_end = cursor + size
+
+        # 내부 슬랙 탐지: 이전 박스 끝 ~ 현재 박스 시작 간의 빈 공간
+        if box_start > last_box_end:
+            slack_regions.append((last_box_end, box_start))
+
+        total_valid += size
+        last_box_end = box_end
+        cursor = box_end
+
+    # EOF 이후 슬랙
+    if last_box_end < file_size:
+        slack_regions.append((last_box_end, file_size))
+
+    slack_bytes = sum(end - start for start, end in slack_regions)
+    slack_ratio = (slack_bytes / file_size) * 100
+
+    return {
+        "total_bytes": file_size,
+        "valid_data_bytes": file_size - slack_bytes,
+        "slack_bytes": slack_bytes,
+        "slack_ratio_percent": round(slack_ratio, 2),
+        "slack_regions": slack_regions
+    }
+
+def analyze_avi_slack(file_path):
+
+    with open(file_path, 'rb') as f:
+        data = f.read()
+
+    file_size = len(data)
+
+    # RIFF 헤더 확인 및 전체 사이즈 계산
+    if data[:4] != b'RIFF':
+        raise ValueError("Invalid AVI file: Missing RIFF header")
+
+    riff_size = int.from_bytes(data[4:8], 'little')
+    riff_end = 8 + riff_size  # 정상적으로 정의된 파일 끝 위치
+
+    # movi 섹션 탐색
+    movi_offset = data.find(b'movi')
+    if movi_offset == -1:
+        raise ValueError("No 'movi' section found")
+
+    cursor = movi_offset + 4
+    chunk_headers = [b'00dc', b'01dc', b'00db', b'01db']
+    slack_regions = []
+    total_valid = 0
+    last_chunk_end = cursor
+
+    while cursor + 8 <= file_size:
+        chunk_id = data[cursor:cursor+4]
+        if chunk_id not in chunk_headers:
+            # 슬랙 영역 시작
+            slack_start = cursor
+            while cursor + 8 <= file_size:
+                possible_id = data[cursor:cursor+4]
+                if possible_id in chunk_headers:
+                    break
+                cursor += 1
+            slack_regions.append((slack_start, cursor))
+            last_chunk_end = cursor
+            continue
+
+        try:
+            chunk_size = struct.unpack('<I', data[cursor+4:cursor+8])[0]
+        except:
+            break
+
+        chunk_end = cursor + 8 + chunk_size
+        if chunk_end > file_size:
+            break
+
+        # 내부 슬랙 감지
+        if cursor > last_chunk_end:
+            slack_regions.append((last_chunk_end, cursor))
+
+        total_valid += (chunk_end - cursor)
+        last_chunk_end = chunk_end
+        cursor = chunk_end
+
+    # EOF 이후 슬랙
+    if riff_end < file_size:
+        slack_regions.append((riff_end, file_size))
+
+    slack_bytes = sum(end - start for start, end in slack_regions)
+    slack_ratio = (slack_bytes / file_size) * 100
+
+    return {
+        "total_bytes": file_size,
+        "valid_data_bytes": file_size - slack_bytes,
+        "slack_bytes": slack_bytes,
+        "slack_ratio_percent": round(slack_ratio, 2),
+        "slack_regions": slack_regions
+    }
+
+
+
+if __name__ == "__main__":
+    file_path = r"C:\Users\user\Desktop\devel\WHS\FineVu_X3000NEW_H265_AVI\FineVu_X3000NEW_H265_AVI\샘플\20250410-13h56m01s_N.avi"
+    ext = file_path.split('.')[-1].lower()
+
+    print("[슬랙 정보 분석 결과]")
+    
+    if ext == "avi":
+        result = analyze_avi_slack(file_path)
+    elif ext == "mp4":
+        result = analyze_mp4_slack(file_path)
+    else:
+        print("지원하지 않는 파일 형식입니다.")
+        exit()
+
+    print(f"전체 크기: {result['total_bytes']} bytes")
+    print(f"사용된 크기: {result['valid_data_bytes']} bytes")
+    print(f"슬랙 크기: {result['slack_bytes']} bytes")
+    print(f"슬랙 비율: {result['slack_ratio_percent']}%")
+    print(f"슬랙 영역 개수: {len(result['slack_regions'])}")

--- a/struc.py
+++ b/struc.py
@@ -1,0 +1,121 @@
+def mp4_parser(file_path):
+    # MP4 박스 계층 구조 정의
+    box_hierarchy = {
+        "moov": ["mvhd", "trak", "udta", "mvex"],  # moov 내부 박스들
+        "trak": ["tkhd", "edts", "mdia"],         # trak 내부 박스들
+        "mdia": ["mdhd", "hdlr", "minf"],         # mdia 내부 박스들
+        "minf": ["vmhd", "smhd", "dinf", "stbl"], # minf 내부 박스들
+        "stbl": ["stsd", "stts", "ctts", "stsc", "stsz", "stz2", "stco", "co64", "stss", "sbgp", "sgpd"],  # 샘플 관련
+        "dinf": ["dref"],                         # dinf 내부 박스
+        "meta": ["hdlr", "ilst"],                 # meta 관련 박스
+        "ilst": ["©nam", "©alb", "©art"],         # 사용자 정의 데이터
+    }
+
+    # MP4 박스 파싱 함수
+    def parse_box(data, offset, file_size, indent_level=0):
+        output = []  # 출력 저장
+
+        while offset < file_size:  # 파일 끝까지 탐색
+            if offset + 8 > file_size:  # 파일 끝 범위 방지
+                break
+
+            # 박스 크기와 타입 읽기
+            box_size = int.from_bytes(data[offset:offset + 4], byteorder='big')  # 박스 크기 (빅 엔디안)
+            box_type = data[offset + 4:offset + 8].decode('utf-8', errors='replace')  # 박스 타입 디코딩
+
+            if box_size < 8 or offset + box_size > file_size:  # 잘못된 박스 크기 처리
+                break
+
+            # 박스 정보 추가
+            output.append(f"{'    ' * indent_level}{box_type} box start offset: {hex(offset)}")  # 박스 시작 위치
+            output.append(f"{'    ' * indent_level}{box_type} box size: {hex(box_size)}")  # 박스 크기
+
+            # 하위 박스가 있으면 재귀적으로 파싱
+            if box_type in box_hierarchy:  # 계층 구조에 정의된 박스만
+                sub_box_output = parse_box(data, offset + 8, offset + box_size, indent_level + 1)  # 내부 탐색
+                output.extend(sub_box_output)
+
+            offset += box_size  # offset 이동
+
+        return output  # 결과 반환
+
+    # 파일 열기 및 데이터 읽기
+    with open(file_path, "rb") as file:
+        data = file.read()
+
+    file_size = len(data)  # 파일 크기 계산
+    output_lines = parse_box(data, 0, file_size)  # MP4 파싱 실행
+    print("\n".join(output_lines))  # 결과 출력
+
+def avi_parser(file_path):
+    with open(file_path, 'rb') as file:
+    # 전체 파일 크기 확인
+        binary_data = file.read()
+        file_size = int.from_bytes(binary_data[4:8], 'little')  # RIFF 크기 추출
+        print(f"file size : 0x{file_size:06X}")
+        print(f"file data size : 0x{file_size + 8:06X}\n")  # RIFF + 8바이트 헤더 포함 크기
+
+        # 파일 처음으로 이동
+        offset = 12  # RIFF 헤더를 건너뛴 위치
+        while offset < len(binary_data):  # 전체 파일 끝까지 탐색
+            # 청크 ID 및 크기 추출
+            chunk_id = binary_data[offset:offset+4]
+            if len(chunk_id) < 4:  # ID를 읽을 수 없으면 종료
+                break
+            chunk_size = int.from_bytes(binary_data[offset+4:offset+8], "little")
+
+            # `stsd` 청크 파싱
+            if chunk_id == b'stsd':
+                stsd_data = binary_data[offset + 8: offset + 8 + chunk_size]
+                print(f"stsd Start Offset : 0x{offset:X}")
+                print(f"stsd Size : 0x{chunk_size:X}")
+                
+                # 코덱 정보 추출
+                codec_type = stsd_data[10:14].decode('ascii', errors='replace')  # 10번째 바이트부터 4바이트(FourCC 코드)
+                print(f"Codec : {codec_type}")
+                
+                # 코덱 데이터 추출
+                codec_data = stsd_data[14:]  # 14번째 바이트부터 끝까지 (코덱 초기화 데이터)
+                print("Codec Data (Binary):")
+                print(codec_data.hex())  # 바이너리 데이터를 헥사로 출력
+
+
+
+
+            # LIST 청크 처리
+            if chunk_id == b'LIST':
+                list_subtype = binary_data[offset+8:offset+12]
+                if list_subtype == b'hdrl':
+                    print(f"[LIST-hdrl] offset: 0x{offset:X} size: 0x{chunk_size:X}")
+                elif list_subtype == b'movi':
+                    print(f"[LIST-movi] offset: 0x{offset:X} size: 0x{chunk_size:X}")
+                elif list_subtype == b'INFO':
+                    print(f"[LIST-INFO] offset: 0x{offset:X} size: 0x{chunk_size:X}")
+
+
+            # 기타 청크 처리
+            elif chunk_id in [b'JUNK', b'idx1']:
+                print(f"{chunk_id.decode(errors='replace')} start offset : 0x{offset:X}")
+                print(f"{chunk_id.decode(errors='replace')} size : 0x{chunk_size:X}\n")
+
+            # offset 이동
+            offset += 8 + chunk_size  # ID(4바이트) + 크기(4바이트) + 데이터 크기
+            if chunk_size % 2 == 1:  # 짝수 정렬 처리 (패딩 바이트 스킵)
+                offset += 1
+
+            # 파일 끝 범위 초과 방지
+            if offset >= len(binary_data):
+                break
+
+if __name__ == "__main__":
+    file_path = r"C:\Users\user\Desktop\devel\WHS\INAVI_QXD1500_H264_MP4\INAVI_QXD1500_H264_MP4\샘플\MOT_2025_04_13_18_00_32_F.MP4"
+    ext = file_path.split('.')[-1].lower()
+
+    print("[파일 구조 파싱 결과]\n")
+    
+    if ext == "mp4":
+        mp4_parser(file_path)
+    elif ext == "avi":
+        avi_parser(file_path)
+    else:
+        print("지원하지 않는 형식입니다.")


### PR DESCRIPTION
### 구조
---
**basic_info_parser.py > 분석 탭 중 '기본 정보'**

- file_format(file_path)
→ AVI/MP4 포맷 판별 (RIFF, ftyp 시그니처 검사)
- file_creation_time(file_path)
→ 생성/수정/접근 시간 반환 (datetime 변환 포함)
- file_size(file_path)
→ 파일 바이트 크기 반환
- video_metadata(file_path)
→ 재생 시간, 코덱, 해상도, 프레임레이트 추출 (ffprobe 사용)
![image](https://github.com/user-attachments/assets/b3fd888a-02da-4a8e-92e2-11d7e9ef4ef1)


**integrity.py > 분석 탭 중 '무결성 검사'**
- avi_damage_check(file_path)
→ AVI 파일 무결성 검사 (RIFF, movi, 프레임 청크 존재 여부 등)
- mp4_damage_check(file_path)
→ MP4 구조 검사 (ftyp, moov, mdat 존재 및 순서 확인)

- 참고로 무결성 검사는 기본적인 구조들이 손실되었을때만 파싱이 가능, 예를 들면 avi의 경우 RIFF 헤더가 없거나 hdrl이 손상되었거나 등등
![image](https://github.com/user-attachments/assets/08379b09-3cae-4cdb-883b-1fd3c71f9711)




**slack.py > 분석 탭 중 '슬랙 정보'**
- analyze_mp4_slack(file_path)
→ MP4 박스 간 내부 슬랙 및 EOF 슬랙 분석
- analyze_avi_slack(file_path)
→ AVI 청크 간 슬랙 및 RIFF 이후 남은 슬랙 분석
![image](https://github.com/user-attachments/assets/648baae3-b0a0-4d25-b955-81e19efed28b)



**struc.py > 분석 탭 중 '구조 정보'**

- mp4_parser(file_path)
→ MP4 박스 계층 구조 파싱 및 위치/크기 출력 (재귀 구조)
![image](https://github.com/user-attachments/assets/550a3d6b-a527-48b4-9855-0858fa9f5edb)
- avi_parser(file_path)
→ AVI RIFF 구조 탐색, 주요 청크(offset/size) 및 코덱 정보 추출
![image](https://github.com/user-attachments/assets/7c967ad5-12d5-47dc-b781-c3028efe7f53)



### 작업 상세 내용
---
[O] file_format
[O] file_creation_time
[O] file_size
[O] video_metadata
[O] avi_damage_check
[O] mp4_damage_check
[O] analyze_mp4_slack
[O] analyze_avi_slack
[O] mp4_parser
[O] avi_parser





### 참고사항 (선택)
---
- 현재 코드에는 main 함수들이 테스트용으로 포함되어 있어 분석 파일 경로가 하드코딩된 상태, 나중에 프론트엔드에서 입력받아오는 형식으로 수정할 예정.

- 코드 효율 또는 주석, 알아보기 힘든 부분 등이 있다면 리뷰 남겨주시기 바랍니다.