### PR TITLE
[FEAT][#9]: MP4 파일 슬랙 영역에서 시그니처 기반 프레임 추출 및 복원 기능 구현

### DIFF
--- a/python_engine/core/recovery/mp4/extract_slack.py
+++ b/python_engine/core/recovery/mp4/extract_slack.py
@@ -1,0 +1,134 @@
+import os
+import re
+import struct
+
+INPUT_FILE = r"E:\Retato\python_engine\sample_video\mp4_sample.mp4"
+OUTPUT_DIR = r"E:\Retato\python_engine\sample_output"
+OUTPUT_FILE = os.path.join(OUTPUT_DIR, "mp4_extract_slack.h264") 
+
+MAX_REASONABLE_CHUNK_SIZE = 10 * 1024 * 1024  # 10MB
+MIN_VALID_BOX_SIZE = 8 # size + type
+MIN_FRAME_SIZE = 5 # 너무 작은 프레임 필터링 기준
+
+def get_slack_after_moov(path):
+    try:
+        with open(path, 'rb') as f:
+            data = f.read()
+    except FileNotFoundError:
+        print(f"[ERROR] 입력 파일을 찾을 수 없습니다: {path}")
+        return b'', None, None
+
+    offset = 0
+    while offset + MIN_VALID_BOX_SIZE <= len(data):
+        try:
+            size = struct.unpack('>I', data[offset:offset + 4])[0]
+        except struct.error:
+            print(f"[ERROR] size 언팩 실패 @ offset=0x{offset:X}")
+            break
+
+        box_type = data[offset + 4:offset + 8].decode("utf-8", errors="ignore")
+
+        if box_type == "moov":
+            return data[offset + size:], offset + size, data[offset:offset + size]
+        
+        if size <   MIN_VALID_BOX_SIZE:
+            print(f"[WARNING]] 비정상적인 박스 크기(size={size}) → 루프 종료 @ offset=0x{offset:X}")
+            break
+
+        offset += size
+
+    return b'', None, None
+
+def extract_sps_pps(moov_data):
+    if moov_data is None:
+        print("[ERROR] moov 박스가 존재하지 않습니다.")
+        return b''
+
+    avcc_pos = moov_data.find(b'avcC')
+    if avcc_pos == -1:
+        print("[ERROR] avcC 박스를 찾을 수 없습니다.")
+        return b''
+
+    avcc_start = avcc_pos + 4
+
+    try:
+        sps_len = struct.unpack('>H', moov_data[avcc_start + 6:avcc_start + 8])[0]
+        sps_start = avcc_start + 8
+        sps = moov_data[sps_start:sps_start + sps_len]
+
+        pps_len_start = sps_start + sps_len + 1
+        pps_len = struct.unpack('>H', moov_data[pps_len_start:pps_len_start + 2])[0]
+        pps_start = pps_len_start + 2
+        pps = moov_data[pps_start:pps_start + pps_len]
+
+        return b'\x00\x00\x00\x01' + sps + b'\x00\x00\x00\x01' + pps
+    except (IndexError, struct.error) as e:
+        print(f"[ERROR] SPS/PPS 추출 실패: {e}")
+        return b''
+
+def recover_from_slack(mp4_path, output_path):
+    slack, slack_offset, moov_data = get_slack_after_moov(mp4_path)
+    if slack_offset is None:
+        print("[ERROR] moov 박스를 찾을 수 없습니다.")
+        return
+
+    print(f"[INFO] 슬랙 영역 시작 offset: 0x{slack_offset:x}")
+
+    if not slack:
+        print("[INFO] 슬랙 영역이 존재하지 않거나 복원 가능한 데이터가 없습니다.")
+        return
+
+    sps_pps = extract_sps_pps(moov_data)
+    if not sps_pps:
+        print("[ERROR] SPS/PPS 추출 실패")
+        return
+
+    iframe_pattern = re.compile(b'\x00.{3}[\x25\x45\x65]\x88\x80')
+    pframe_pattern = re.compile(b'\x00\x00.{2}[\x21\x41\x61]\x9A')
+
+    matches = []
+    for ftype, pattern in [("I", iframe_pattern), ("P", pframe_pattern)]:
+        for m in pattern.finditer(slack):
+            matches.append((m.start(), ftype))
+
+    matches.sort(key=lambda x: x[0])
+
+    has_i_frame = any(ftype == "I" for _, ftype in matches)
+    if not has_i_frame or len(matches) < 3:
+        print("[INFO] 슬랙 영역이 존재하지 않거나 복원 가능한 데이터가 없습니다.")
+        return
+
+    try:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    except PermissionError:
+        print("[ERROR] 출력 디렉토리를 생성할 수 없습니다")
+        return
+    
+    recovered = 0
+    with open(output_path, 'wb') as f:
+        f.write(sps_pps)
+        for start, ftype in matches:
+            try:
+                size = struct.unpack('>I', slack[start:start + 4])[0]
+                if size > MAX_REASONABLE_CHUNK_SIZE:
+                    print(f"[WARNING] 너무 큰 프레임 size={size} @ offset=0x{slack_offset + start:X}")
+                    continue
+                if size < MIN_FRAME_SIZE:
+                    print(f"[WARNING] 너무 작은 프레임 size={size} @ offset=0x{slack_offset + start:X}")
+                    continue
+
+                end = start + 4 + size
+                if end > len(slack):
+                    print(f"[WARNING] 프레임이 슬랙 영역을 초과함 (offset=0x{slack_offset + start:X}, size={size})")
+                    continue
+
+                f.write(b'\x00\x00\x00\x01' + slack[start + 4:end])
+                print(f"[{ftype}-Frame] @ offset 0x{slack_offset + start:X}, size={size}")
+                recovered += 1
+            except (struct.error, IndexError):
+                continue
+
+    print(f"[INFO] 총 {recovered}개 프레임 저장 완료 → {output_path}")
+
+if __name__ == "__main__":
+    recover_from_slack(INPUT_FILE, OUTPUT_FILE)


### PR DESCRIPTION
## 작업 내용
- `.mp4` 파일의 `moov` 박스 이후 슬랙 영역을 탐색하여, 유효한 NAL 단위(I-Frame/P-Frame)를 기반으로 `.h264` 비디오 스트림을 복원하는 기능을 구현했습니다.
- 슬랙 영역 내 프레임은 바이너리 시그니처(`I`: `0x25|0x45|0x65`, `P`: `0x21|0x41|0x61`)를 기반으로 탐지하며, SPS/PPS NAL도 `moov` 내 `avcC` 박스에서 추출하여 함께 저장됩니다.
- 복원된 `.h264` 스트림은 기존 변환 도구 (`convert_video.py`)를 통해 `.mp4`로 변환할 수 있습니다.

### 관련 파일 경로
- `python_engine/core/recovery/mp4/extract_slack.py`: MP4 슬랙 영역 복원 로직
- `python_engine/tests/convert_video.py`: `.h264` → `.mp4` 변환 도구 (기존 테스트 코드 그대로 사용)

### 참고 사항
- 현재는 테스트를 위해 샘플 MP4 파일을 절대경로로 지정하고 있습니다. 이후 사용자 입력 방식으로 개선 예정입니다.
- 슬랙 영역에 프레임은 존재하지만 `I-Frame`이 없거나, 총 프레임 수가 3개 미만일 경우 "복원 불가능"으로 간주하여 사용자 피드백을 출력합니다.

### 스크린샷
![image](https://github.com/user-attachments/assets/ed473dd4-3f4a-4e18-b081-6d6b1d0345b4)
> **설명**: `extract_slack.py` 실행 결과. MP4 파일 내 `moov` 박스 이후 슬랙 영역에서 복원 가능한 NAL 프레임(I/P 프레임)을 탐지하여 `.h264` 스트림으로 추출한 로그입니다.
> 유효한 SPS/PPS 정보가 포함되어 있으며, `I-Frame` 존재 여부 및 총 프레임 수를 기준으로 복원 가능 여부를 판단합니다. 

![image](https://github.com/user-attachments/assets/69369d40-5ed1-4a1f-8ff8-39d337b5c71c)
> **설명**: 슬랙 영역에서 복원 가능한 프레임이 3개 미만으로 판단되어 `.h264` 추출을 진행하지 않은 사례입니다.
> 현재 로직에서는 너무 적은 프레임 수로 인해 재생 불가 가능성이 높다고 판단하여, 슬랙 영역이 없는 것으로 간주해 복원을 건너뜁니다.
 

## 리뷰 요구사항: 
- **슬랙 영역에 프레임이 일부 존재하더라도** `I-Frame`이 없거나 총 프레임 수가 3개 미만일 경우 복원 불가능으로 판단하는 현재 기준이 괜찮을지 의견 부탁드립니다.
