### PR TITLE
[FEAT][#14] 영상 다운로드 기능 구현

### DIFF
--- a/python_engine/core/output/download_video.py
+++ b/python_engine/core/output/download_video.py
@@ -27,7 +27,7 @@ def classifty_video_name(filename):
 
     timestamp = datetime.fromtimestamp(os.path.getmtime(filename)).strftime('%Y%m%d_%H%M%S')
 
-    label = "_SLACK" if is_slack else ""
+    label = "_HIDDEN" if is_slack else ""
     if is_front:
         stem = f"{timestamp}_FRONT{label}"
     elif is_rear:

--- a/python_engine/core/output/download_video.py
+++ b/python_engine/core/output/download_video.py
@@ -1,0 +1,84 @@
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+SAMPLE_VIDEO_DIR = r"E:\Retato\python_engine\sample_video"
+OUTPUT_VIDEO_DIR = r"E:\Retato\python_engine\sample_output\output_video"
+DOWNLOAD_DIR = os.path.join(Path.home(), "Downloads")
+os.makedirs(DOWNLOAD_DIR, exist_ok=True)
+
+def list_videos():
+    videos = []
+    for directory in [SAMPLE_VIDEO_DIR, OUTPUT_VIDEO_DIR]:
+        for file in os.listdir(directory):
+            if file.lower().endswith(('.mp4', '.avi')):
+                videos.append(os.path.join(directory, file))
+    return videos
+
+def classifty_video_name(filename):
+    name = os.path.basename(filename)
+    stem, ext = os.path.splitext(name)
+    ext = ext.lower()
+
+    is_slack = 'slack' in stem.lower()
+    is_front = 'front' in stem.lower()
+    is_rear = 'rear' in stem.lower()
+
+    timestamp = datetime.fromtimestamp(os.path.getmtime(filename)).strftime('%Y%m%d_%H%M%S')
+
+    label = "_SLACK" if is_slack else ""
+    if is_front:
+        stem = f"{timestamp}_FRONT{label}"
+    elif is_rear:
+        stem = f"{timestamp}_REAR{label}"
+    elif SAMPLE_VIDEO_DIR in filename:
+        stem = stem  # 원본 파일은 이름 그대로
+    else:
+        stem = f"{timestamp}{label}"
+
+    return stem
+    
+def download_selected_videos():
+    videos = list_videos()
+    if not videos:
+        print("[INFO] 복원된 영상이 존재하지 않습니다.")
+        return
+    
+    print("\n[영상 목록]")
+    for idx, video in enumerate(videos):
+        print(f"{idx + 1}. {os.path.basename(video)}")
+
+    selected = input("\n다운로드할 영상 번호를 쉼표(,)로 구분하여 입력하세요 (예: 1,3,4):" )
+    selected_indexes = [int(x.strip()) - 1 for x in selected.split(',') if x.strip().isdigit()]
+
+    if not selected_indexes:
+        print("[ERROR] 유효한 선택이 없습니다.")
+        return
+    
+    format_input = input("다운로드 포맷을 선택하세요 (mp4 또는 avi): ").strip().lower()
+    if format_input not in ["mp4", "avi"]:
+        print("[ERROR] 지원되지 않는 포맷입니다.")
+        return
+    
+    for idx in selected_indexes:
+        try:
+            src = videos[idx]
+            dst_stem = classifty_video_name(src)
+            dst_filename = f"{dst_stem}.{format_input}"
+            dst_path = os.path.join(DOWNLOAD_DIR, dst_filename)
+
+            # 이미 같은 이름이 있다면 _copy 붙여서 저장
+            counter = 1
+            while os.path.exists(dst_path):
+                dst_filename = f"{dst_stem}_copy{counter}.{format_input}"
+                dst_path = os.path.join(DOWNLOAD_DIR, dst_filename)
+                counter += 1
+
+            shutil.copy2(src, dst_path)
+            print(f"[SUCCESS] {dst_filename} 다운로드 완료 → {DOWNLOAD_DIR}")
+        except Exception as e:
+            print(f"[ERROR] {os.path.basename(src)} 다운로드 실패: {e}")
+
+if __name__ == "__main__":
+    download_selected_videos()


### PR DESCRIPTION
## 작업 내용
- 복원된 영상 파일(MP4/AVI)을 사용자가 선택한 포맷으로 **로컬 `Downloads` 폴더에 다운로드**하는 기능을 구현했습니다.
- 영상 파일명은 **전방/후방 채널 정보, 타임스탬프, 슬랙 여부**에 따라 자동 생성됩니다.
- CLI 환경에서 **사용자 입력을 통해 영상 선택 및 포맷 지정**이 가능합니다.

### 관련 파일 경로
- `python_engine/core/output/download_video.py`: 사용자 선택 기반으로 영상 파일을 지정 포맷으로 다운로드하는 CLI 도구
    - `sample_video` 및 `output_video` 내 영상을 대상으로 작동
    - 채널명 / 슬랙 여부 / 타임스탬프를 기반으로 파일명을 생성하고, **중복 파일 존재시 자동으로 `_copy1`, `_copy2`를 붙여 저장**

### 스크린샷 (선택) 
 ![image](https://github.com/user-attachments/assets/d4c64577-a738-445d-993c-96d0366c10d3)
![image](https://github.com/user-attachments/assets/a2a5d6f0-ab2f-4501-8ad8-f518a4c9f2c5)

### 참고 사항
- 파일 저장 위치는 **사용자 계정의 기본 Downloads 디렉토리**입니다. (`C:/Users/사용자명/Downloads`)
- 현재 CLI 기반으로 작동하며, UI 연동 시 사용자 선택/입력 방식은 별도로 처리 예정입니다.
- 중복된 파일명이 있을 경우 자동으로 `_copy1`, `_copy2` 등으로 이름을 변경하여 덮어쓰기 방지합니다.

## 리뷰 요구사항 (선택)
- 파일명 자동 생성 규칙(`타임스탬프 + [FRONT/REAR] + _SLACK`)이 사용자 입장에서 명확한지 의견 주시면 감사하겠습니다.
