### PR TITLE
[FEAT][#23] 프레임 이미지 ZIP 다운로드 기능

### DIFF
--- a/python_engine/core/output/download_frame.py
+++ b/python_engine/core/output/download_frame.py
@@ -1,0 +1,110 @@
+import os
+import zipfile
+import subprocess
+from datetime import datetime
+from pathlib import Path
+import tempfile
+
+SAMPLE_VIDEO_DIR = r"E:\Retato\python_engine\sample_video"
+OUTPUT_VIDEO_DIR = r"E:\Retato\python_engine\sample_output\output_video"
+DOWNLOAD_DIR = os.path.join(Path.home(), "Downloads")
+FRAME_EXTRACTOR = os.path.abspath("bin/ffmpeg.exe")
+os.makedirs(DOWNLOAD_DIR, exist_ok=True)
+
+def list_videos():
+    videos = []
+    for directory in [SAMPLE_VIDEO_DIR, OUTPUT_VIDEO_DIR]:
+        for file in os.listdir(directory):
+            if file.lower().endswith(('.mp4', '.avi')):
+                videos.append(os.path.join(directory, file))
+    return videos
+
+def classify_zip_name(filename):
+    name = os.path.basename(filename)
+    stem, ext = os.path.splitext(name)
+    ext = ext.lower()
+
+    is_slack = 'slack' in stem.lower()
+    is_front = 'front' in stem.lower()
+    is_rear = 'rear' in stem.lower()
+
+    timestamp = datetime.fromtimestamp(os.path.getmtime(filename)).strftime('%Y%m%d_%H%M%S')
+
+    label = "_SLACK" if is_slack else ""
+    if is_front:
+        stem = f"{timestamp}_FRONT{label}"
+    elif is_rear:
+        stem = f"{timestamp}_REAR{label}"
+    elif SAMPLE_VIDEO_DIR in filename:
+        stem = stem  # 원본 파일은 이름 그대로
+    else:
+        stem = f"{timestamp}{label}"
+
+    return f"{stem}.zip"
+
+def extract_frames_with_ffmpeg(video_path, output_dir):
+    cmd = [
+        FRAME_EXTRACTOR,
+        "-i", video_path,
+        "-q:v", "2",
+        os.path.join(output_dir, "frame_%03d.jpg")
+    ]
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+    
+def zip_directory(source_dir, zip_path):
+    with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        for root, _, files in os.walk(source_dir):
+            for file in files:
+                file_path = os.path.join(root, file)
+                arcname = os.path.relpath(file_path, source_dir)
+                zipf.write(file_path, arcname)
+
+def zip_frames_from_selected_videos():
+    videos = list_videos()
+    if not videos:
+        print("[INFO] 압축 가능한 영상 파일이 없습니다.")
+        return
+    
+    print("\n[영상 목록]")
+    for idx, video in enumerate(videos):
+        print(f"{idx + 1}. {os.path.basename(video)}")
+
+    selected = input("\n프레임을 추출하여 압축할 영상 번호를 쉼표(,)로 구분하여 입력하세요 (예: 1,3): ")
+    selected_indexes = [int(x.strip()) - 1 for x in selected.split(',') if x.strip().isdigit()]
+
+    if not selected_indexes:
+        print("[ERROR] 유효한 선택이 없습니다.")
+        return
+    
+    for idx in selected_indexes:
+        try:
+            video_path = videos[idx]
+            zip_name = classify_zip_name(video_path)
+            zip_base, zip_ext = os.path.splitext(zip_name)
+            zip_path = os.path.join(DOWNLOAD_DIR, zip_name)
+
+            counter = 1
+            while os.path.exists(zip_path):
+                zip_name = f"{zip_base}_copy{counter}{zip_ext}"
+                zip_path = os.path.join(DOWNLOAD_DIR, zip_name)
+                counter += 1
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                print(f"[INFO] 프레임 추출 중: {os.path.basename(video_path)}...")
+                success = extract_frames_with_ffmpeg(video_path, temp_dir)
+                if not success:
+                    print(f"[ERROR] {os.path.basename(video_path)} 프레임 추출 실패")
+                    continue
+
+                zip_directory(temp_dir, zip_path)
+                print(f"[SUCCESS] {zip_name} 저장 완료 → {DOWNLOAD_DIR}")
+
+        except Exception as e:
+            print(f"[ERROR] {os.path.basename(videos[idx])} 처리 실패: {e}")
+        
+if __name__ == "__main__":
+    zip_frames_from_selected_videos()

--- a/python_engine/core/output/download_frame.py
+++ b/python_engine/core/output/download_frame.py
@@ -30,7 +30,7 @@ def classify_zip_name(filename):
 
     timestamp = datetime.fromtimestamp(os.path.getmtime(filename)).strftime('%Y%m%d_%H%M%S')
 
-    label = "_SLACK" if is_slack else ""
+    label = "_HIDDEN" if is_slack else ""
     if is_front:
         stem = f"{timestamp}_FRONT{label}"
     elif is_rear:

--- a/python_engine/core/output/download_video.py
+++ b/python_engine/core/output/download_video.py
@@ -1,0 +1,84 @@
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+SAMPLE_VIDEO_DIR = r"E:\Retato\python_engine\sample_video"
+OUTPUT_VIDEO_DIR = r"E:\Retato\python_engine\sample_output\output_video"
+DOWNLOAD_DIR = os.path.join(Path.home(), "Downloads")
+os.makedirs(DOWNLOAD_DIR, exist_ok=True)
+
+def list_videos():
+    videos = []
+    for directory in [SAMPLE_VIDEO_DIR, OUTPUT_VIDEO_DIR]:
+        for file in os.listdir(directory):
+            if file.lower().endswith(('.mp4', '.avi')):
+                videos.append(os.path.join(directory, file))
+    return videos
+
+def classifty_video_name(filename):
+    name = os.path.basename(filename)
+    stem, ext = os.path.splitext(name)
+    ext = ext.lower()
+
+    is_slack = 'slack' in stem.lower()
+    is_front = 'front' in stem.lower()
+    is_rear = 'rear' in stem.lower()
+
+    timestamp = datetime.fromtimestamp(os.path.getmtime(filename)).strftime('%Y%m%d_%H%M%S')
+
+    label = "_SLACK" if is_slack else ""
+    if is_front:
+        stem = f"{timestamp}_FRONT{label}"
+    elif is_rear:
+        stem = f"{timestamp}_REAR{label}"
+    elif SAMPLE_VIDEO_DIR in filename:
+        stem = stem  # 원본 파일은 이름 그대로
+    else:
+        stem = f"{timestamp}{label}"
+
+    return stem
+    
+def download_selected_videos():
+    videos = list_videos()
+    if not videos:
+        print("[INFO] 복원된 영상이 존재하지 않습니다.")
+        return
+    
+    print("\n[영상 목록]")
+    for idx, video in enumerate(videos):
+        print(f"{idx + 1}. {os.path.basename(video)}")
+
+    selected = input("\n다운로드할 영상 번호를 쉼표(,)로 구분하여 입력하세요 (예: 1,3,4):" )
+    selected_indexes = [int(x.strip()) - 1 for x in selected.split(',') if x.strip().isdigit()]
+
+    if not selected_indexes:
+        print("[ERROR] 유효한 선택이 없습니다.")
+        return
+    
+    format_input = input("다운로드 포맷을 선택하세요 (mp4 또는 avi): ").strip().lower()
+    if format_input not in ["mp4", "avi"]:
+        print("[ERROR] 지원되지 않는 포맷입니다.")
+        return
+    
+    for idx in selected_indexes:
+        try:
+            src = videos[idx]
+            dst_stem = classifty_video_name(src)
+            dst_filename = f"{dst_stem}.{format_input}"
+            dst_path = os.path.join(DOWNLOAD_DIR, dst_filename)
+
+            # 이미 같은 이름이 있다면 _copy 붙여서 저장
+            counter = 1
+            while os.path.exists(dst_path):
+                dst_filename = f"{dst_stem}_copy{counter}.{format_input}"
+                dst_path = os.path.join(DOWNLOAD_DIR, dst_filename)
+                counter += 1
+
+            shutil.copy2(src, dst_path)
+            print(f"[SUCCESS] {dst_filename} 다운로드 완료 → {DOWNLOAD_DIR}")
+        except Exception as e:
+            print(f"[ERROR] {os.path.basename(src)} 다운로드 실패: {e}")
+
+if __name__ == "__main__":
+    download_selected_videos()


### PR DESCRIPTION
## 작업 내용
- 복원된 영상 파일(MP4/AVI)에서 **프레임 이미지를 추출**하고, 이를 **ZIP 압축하여 Downloads 폴더에 저장**하는 기능을 구현했습니다.
- 영상 파일명은 **전방/후방 채널 정보, 타임스탬프, 슬랙 여부**에 따라 자동 생성됩니다.
- CLI 환경에서 **사용자가 추출 대상 영상을 번호로 선택**하면 프레임을 실시간 추출 후 압축합니다.

### 관련 파일 경로
- `python_engine/core/output/download_frame.py`: 사용자가 선택한 영상에서 프레임을 추출하여 영상 단위 ZIP 파일로 다운로드
    - `sample_video` 및 `output_video` 내 영상을 대상으로 작동
    - 영상별로 `FFmpeg`을 통해 프레임을 추출한 뒤, **임시 디렉토리에 저장 후 ZIP 압축**
    - **중복된 ZIP 파일명은 `_copy1`, `_copy2` 식으로 자동 처리**

### 스크린샷 (선택) 
![image](https://github.com/user-attachments/assets/7002f0a5-86ee-4576-af01-64aa204f29be)
![image](https://github.com/user-attachments/assets/f2d0a198-62c5-4c5b-a89d-600451526c4d)

### 참고 사항
- 프레임 추출은 **영상별로 개별 실행**되며, ZIP 파일은 **Downloads 폴더**에 저장됩니다.
- **ZIP 파일명은 `타임스탬프_[FRONT/REAR][_SLACK].zip` 또는 기존 원본명.zip** 형식입니다.
- 중복된 파일이 있을 경우 자동으로 이름을 변경하여 저장됩니다.